### PR TITLE
Add extra new line to separate paragraphs.

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -165,7 +165,7 @@ func HTML2Text(html string) string {
 				outBuf.WriteString("\r\n")
 			} else if tagName == "p" || tagName == "/p" {
 				if canPrintNewline {
-					outBuf.WriteString("\r\n")
+					outBuf.WriteString("\r\n\r\n")
 				}
 				canPrintNewline = false
 			} else if badTagnamesRE.MatchString(tagName) {

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -23,7 +23,7 @@ func TestHTML2Text(t *testing.T) {
 		Convey("Line breaks", func() {
 			So(HTML2Text("should \nignore \r\nnew lines"), ShouldEqual, "should ignore new lines")
 			So(HTML2Text(`two<br>line<br/>breaks`), ShouldEqual, "two\r\nline\r\nbreaks")
-			So(HTML2Text(`<p>two</p><p>paragraphs</p>`), ShouldEqual, "two\r\nparagraphs")
+			So(HTML2Text(`<p>two</p><p>paragraphs</p>`), ShouldEqual, "two\r\n\r\nparagraphs")
 		})
 
 		Convey("HTML entities", func() {


### PR DESCRIPTION
Add extra new line for paragraphs so that we can differentiate  between a line break and paragraphs