### PR TITLE
Fix bad tag pattern, add support for custom entities

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -13,7 +13,7 @@ const (
 )
 
 var lbr = WIN_LBR
-var badTagnamesRE = regexp.MustCompile(`^(head|script|style|a)($|\s*)`)
+var badTagnamesRE = regexp.MustCompile(`^(head|script|style|a)($|\s+)`)
 var linkTagRE = regexp.MustCompile(`a.*href=('([^']*?)'|"([^"]*?)")`)
 var badLinkHrefRE = regexp.MustCompile(`javascript:`)
 var headersRE = regexp.MustCompile(`^(\/)?h[1-6]`)

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -87,5 +87,11 @@ func TestHTML2Text(t *testing.T) {
 			So(HTML2Text(`<p>two</p><p>paragraphs</p>`), ShouldEqual, "two\r\n\r\nparagraphs")
 		})
 
+		Convey("Custom HTML Tags", func() {
+			So(HTML2Text(`<aa>hello</aa>`), ShouldEqual, "hello")
+			So(HTML2Text(`<aa >hello</aa>`), ShouldEqual, "hello")
+			So(HTML2Text(`<aa x="1">hello</aa>`), ShouldEqual, "hello")
+		})
+
 	})
 }


### PR DESCRIPTION
Make custom tags like '<aa></aa>' work