### PR TITLE
UUIO-733: format HTML to populate the service provider eligibility field

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -8,14 +8,11 @@ import (
 )
 
 const (
-	// WinLbr Windows line break
-	WinLbr = "\r\n"
-
-	// UnixLbr Unix line break
-	UnixLbr = "\n"
+	WIN_LBR  = "\r\n"
+	UNIX_LBR = "\n"
 )
 
-var lbr = WinLbr
+var lbr = WIN_LBR
 var badTagnamesRE = regexp.MustCompile(`^(head|script|style|a)($|\s+)`)
 var linkTagRE = regexp.MustCompile(`a.*href=('([^']*?)'|"([^"]*?)")`)
 var badLinkHrefRE = regexp.MustCompile(`javascript:`)
@@ -52,9 +49,9 @@ func parseHTMLEntity(entName string) (string, bool) {
 // with argument false sets Windows-style line-breaks in output ("\r\n", the default)
 func SetUnixLbr(b bool) {
 	if b {
-		lbr = UnixLbr
+		lbr = UNIX_LBR
 	} else {
-		lbr = WinLbr
+		lbr = WIN_LBR
 	}
 }
 
@@ -188,16 +185,12 @@ func HTML2Text(html string) string {
 			if tagNameLowercase == "/ul" {
 				outBuf.WriteString(lbr)
 			} else if tagNameLowercase == "li" || tagNameLowercase == "li/" {
-				// UUIO-733 - Added dash for list items.
-				outBuf.WriteString(lbr + "- ")
+				outBuf.WriteString(lbr)
 			} else if headersRE.MatchString(tagNameLowercase) {
 				if canPrintNewline {
 					outBuf.WriteString(lbr + lbr)
 				}
 				canPrintNewline = false
-			} else if tagNameLowercase == "/ol" {
-				// UUIO-733 Added newline when reaching the end of an ordered list.
-				outBuf.WriteString(lbr)
 			} else if tagNameLowercase == "br" || tagNameLowercase == "br/" {
 				// new line
 				outBuf.WriteString(lbr)
@@ -236,24 +229,6 @@ func HTML2Text(html string) string {
 			outBuf.WriteRune(r)
 		}
 	}
-	return splitOutOfBoundsLines(outBuf.String())
-}
 
-/*
-	splitOutOfBoundsLines takes a single string and splits any characters
-	after the 250th character on to a new line.  The method does this
-	recursively on the whole string.
-*/
-func splitOutOfBoundsLines(formattedString string) (splitLine string) {
-	const MaxLineLength = 250
-	lines := strings.SplitAfter(formattedString, lbr)
-	splitLine = ""
-	for _, line := range lines {
-		if len(line) > MaxLineLength {
-			splitLine = line[:MaxLineLength] + lbr + splitOutOfBoundsLines(line[MaxLineLength:])
-		} else {
-			splitLine += line
-		}
-	}
-	return splitLine
+	return outBuf.String()
 }

--- a/html2text.go
+++ b/html2text.go
@@ -8,11 +8,14 @@ import (
 )
 
 const (
-	WIN_LBR  = "\r\n"
-	UNIX_LBR = "\n"
+	// WinLbr Windows line break
+	WinLbr = "\r\n"
+
+	// UnixLbr Unix line break
+	UnixLbr = "\n"
 )
 
-var lbr = WIN_LBR
+var lbr = WinLbr
 var badTagnamesRE = regexp.MustCompile(`^(head|script|style|a)($|\s+)`)
 var linkTagRE = regexp.MustCompile(`a.*href=('([^']*?)'|"([^"]*?)")`)
 var badLinkHrefRE = regexp.MustCompile(`javascript:`)
@@ -49,9 +52,9 @@ func parseHTMLEntity(entName string) (string, bool) {
 // with argument false sets Windows-style line-breaks in output ("\r\n", the default)
 func SetUnixLbr(b bool) {
 	if b {
-		lbr = UNIX_LBR
+		lbr = UnixLbr
 	} else {
-		lbr = WIN_LBR
+		lbr = WinLbr
 	}
 }
 
@@ -185,12 +188,16 @@ func HTML2Text(html string) string {
 			if tagNameLowercase == "/ul" {
 				outBuf.WriteString(lbr)
 			} else if tagNameLowercase == "li" || tagNameLowercase == "li/" {
-				outBuf.WriteString(lbr)
+				// UUIO-733 - Added dash for list items.
+				outBuf.WriteString(lbr + "- ")
 			} else if headersRE.MatchString(tagNameLowercase) {
 				if canPrintNewline {
 					outBuf.WriteString(lbr + lbr)
 				}
 				canPrintNewline = false
+			} else if tagNameLowercase == "/ol" {
+				// UUIO-733 Added newline when reaching the end of an ordered list.
+				outBuf.WriteString(lbr)
 			} else if tagNameLowercase == "br" || tagNameLowercase == "br/" {
 				// new line
 				outBuf.WriteString(lbr)
@@ -229,6 +236,24 @@ func HTML2Text(html string) string {
 			outBuf.WriteRune(r)
 		}
 	}
+	return splitOutOfBoundsLines(outBuf.String())
+}
 
-	return outBuf.String()
+/*
+	splitOutOfBoundsLines takes a single string and splits any characters
+	after the 250th character on to a new line.  The method does this
+	recursively on the whole string.
+*/
+func splitOutOfBoundsLines(formattedString string) (splitLine string) {
+	const MaxLineLength = 250
+	lines := strings.SplitAfter(formattedString, lbr)
+	splitLine = ""
+	for _, line := range lines {
+		if len(line) > MaxLineLength {
+			splitLine = line[:MaxLineLength] + lbr + splitOutOfBoundsLines(line[MaxLineLength:])
+		} else {
+			splitLine += line
+		}
+	}
+	return splitLine
 }

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -1,3 +1,25 @@
+// MIT License
+
+// Copyright (c) 2017 Mario K3A Hros (www.k3a.me)
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package html2text
 
 import (
@@ -57,7 +79,8 @@ func TestHTML2Text(t *testing.T) {
 				ShouldEqual, "would you pay in ¢, £, ¥ or €?")
 			So(HTML2Text(`Tom & Jerry is not an entity`), ShouldEqual, "Tom & Jerry is not an entity")
 			So(HTML2Text(`this &neither; as you see`), ShouldEqual, "this &neither; as you see")
-			So(HTML2Text(`list of items<ul><li>One</li><li>Two</li><li>Three</li></ul>`), ShouldEqual, "list of items\r\nOne\r\nTwo\r\nThree\r\n")
+			So(HTML2Text(`list of items<ul><li>One</li><li>Two</li><li>Three</li></ul>`), ShouldEqual, "list of items\r\n- One\r\n- Two\r\n- Three\r\n")
+			So(HTML2Text(`list of items<ol><li>One</li><li>Two</li><li>Three</li></ol>`), ShouldEqual, "list of items\r\n- One\r\n- Two\r\n- Three\r\n")
 			So(HTML2Text(`fish &amp; chips`), ShouldEqual, "fish & chips")
 			So(HTML2Text(`&quot;I'm sorry, Dave. I'm afraid I can't do that.&quot; – HAL, 2001: A Space Odyssey`), ShouldEqual, "\"I'm sorry, Dave. I'm afraid I can't do that.\" – HAL, 2001: A Space Odyssey")
 			So(HTML2Text(`Google &reg;`), ShouldEqual, "Google ®")
@@ -92,6 +115,13 @@ func TestHTML2Text(t *testing.T) {
 			So(HTML2Text(`<aa>hello</aa>`), ShouldEqual, "hello")
 			So(HTML2Text(`<aa >hello</aa>`), ShouldEqual, "hello")
 			So(HTML2Text(`<aa x="1">hello</aa>`), ShouldEqual, "hello")
+		})
+
+		Convey("Split strings longer than 250", func() {
+			So(HTML2Text(`<aa>UTCwUZ6sibdSsefMTrPg52Ows4uQSBXKjM0gJAvKxf7CeXYvKzf5lJd1I2nP3hXQ3soi9GZLYZmpumeIYlRIq0PJiDO0c9WHW6dU8OaHAFx1C5eF3QA22Cr6sVsWRbr1cBXPqtvWgfnM0KNgDgGKtg7afSLSIdTMNI6xNx8AFB0COO6zp17V2HWeCVVgwmWct5UEB1DlZG2m3TLfFtQ1hByB7fNgZNoRX67E4CdpDJezY7zoabasGDxFr2</aa>`),
+				ShouldEqual, "UTCwUZ6sibdSsefMTrPg52Ows4uQSBXKjM0gJAvKxf7CeXYvKzf5lJd1I2nP3hXQ3soi9GZLYZmpumeIYlRIq0PJiDO0c9WHW6dU8OaHAFx1C5eF3QA22Cr6sVsWRbr1cBXPqtvWgfnM0KNgDgGKtg7afSLSIdTMNI6xNx8AFB0COO6zp17V2HWeCVVgwmWct5UEB1DlZG2m3TLfFtQ1hByB7fNgZNoRX67E4CdpDJezY7zoabasGDxFr2")
+			So(HTML2Text(`<aa>UTCwUZ6sibdSsefMTrPg52Ows4uQSBXKjM0gJAvKxf7CeXYvKzf5lJd1I2nP3hXQ3soi9GZLYZmpumeIYlRIq0PJiDO0c9WHW6dU8OaHAFx1C5eF3QA22Cr6sVsWRbr1cBXPqtvWgfnM0KNgDgGKtg7afSLSIdTMNI6xNx8AFB0COO6zp17V2HWeCVVgwmWct5UEB1DlZG2m3TLfFtQ1hByB7fNgZNoRX67E4CdpDJezY7zoabasGDxFr2Rfino5IlkX1TyVRqx9dm2eTRdFAPW6xK4uPo8pVjmnqiQ4uOPtaJqkZhTwp60lX3fqrtzW1umqISS5Q6497tzBBghTwCoT2MC2GyRFJennWvvdjBsYQ9TQJbWfUxMLFKCG0PSis7Z3csFMJDwqd8kOImcrBvIShwm7nRa3zK16lZELCgNAtMVQPGpOTroS0o6w29tfX4C4S2KdzlCTiGu0QWO5Dmed4mIi8N2kml1dGNR6sHAoCqT5KWqE</aa>`),
+				ShouldEqual, "UTCwUZ6sibdSsefMTrPg52Ows4uQSBXKjM0gJAvKxf7CeXYvKzf5lJd1I2nP3hXQ3soi9GZLYZmpumeIYlRIq0PJiDO0c9WHW6dU8OaHAFx1C5eF3QA22Cr6sVsWRbr1cBXPqtvWgfnM0KNgDgGKtg7afSLSIdTMNI6xNx8AFB0COO6zp17V2HWeCVVgwmWct5UEB1DlZG2m3TLfFtQ1hByB7fNgZNoRX67E4CdpDJezY7zoabasGDxFr2\r\nRfino5IlkX1TyVRqx9dm2eTRdFAPW6xK4uPo8pVjmnqiQ4uOPtaJqkZhTwp60lX3fqrtzW1umqISS5Q6497tzBBghTwCoT2MC2GyRFJennWvvdjBsYQ9TQJbWfUxMLFKCG0PSis7Z3csFMJDwqd8kOImcrBvIShwm7nRa3zK16lZELCgNAtMVQPGpOTroS0o6w29tfX4C4S2KdzlCTiGu0QWO5Dmed4mIi8N2kml1dGNR6sHAoCqT5KWqE")
 		})
 
 	})

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -1,25 +1,3 @@
-// MIT License
-
-// Copyright (c) 2017 Mario K3A Hros (www.k3a.me)
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 package html2text
 
 import (
@@ -79,8 +57,7 @@ func TestHTML2Text(t *testing.T) {
 				ShouldEqual, "would you pay in ¢, £, ¥ or €?")
 			So(HTML2Text(`Tom & Jerry is not an entity`), ShouldEqual, "Tom & Jerry is not an entity")
 			So(HTML2Text(`this &neither; as you see`), ShouldEqual, "this &neither; as you see")
-			So(HTML2Text(`list of items<ul><li>One</li><li>Two</li><li>Three</li></ul>`), ShouldEqual, "list of items\r\n- One\r\n- Two\r\n- Three\r\n")
-			So(HTML2Text(`list of items<ol><li>One</li><li>Two</li><li>Three</li></ol>`), ShouldEqual, "list of items\r\n- One\r\n- Two\r\n- Three\r\n")
+			So(HTML2Text(`list of items<ul><li>One</li><li>Two</li><li>Three</li></ul>`), ShouldEqual, "list of items\r\nOne\r\nTwo\r\nThree\r\n")
 			So(HTML2Text(`fish &amp; chips`), ShouldEqual, "fish & chips")
 			So(HTML2Text(`&quot;I'm sorry, Dave. I'm afraid I can't do that.&quot; – HAL, 2001: A Space Odyssey`), ShouldEqual, "\"I'm sorry, Dave. I'm afraid I can't do that.\" – HAL, 2001: A Space Odyssey")
 			So(HTML2Text(`Google &reg;`), ShouldEqual, "Google ®")
@@ -115,13 +92,6 @@ func TestHTML2Text(t *testing.T) {
 			So(HTML2Text(`<aa>hello</aa>`), ShouldEqual, "hello")
 			So(HTML2Text(`<aa >hello</aa>`), ShouldEqual, "hello")
 			So(HTML2Text(`<aa x="1">hello</aa>`), ShouldEqual, "hello")
-		})
-
-		Convey("Split strings longer than 250", func() {
-			So(HTML2Text(`<aa>UTCwUZ6sibdSsefMTrPg52Ows4uQSBXKjM0gJAvKxf7CeXYvKzf5lJd1I2nP3hXQ3soi9GZLYZmpumeIYlRIq0PJiDO0c9WHW6dU8OaHAFx1C5eF3QA22Cr6sVsWRbr1cBXPqtvWgfnM0KNgDgGKtg7afSLSIdTMNI6xNx8AFB0COO6zp17V2HWeCVVgwmWct5UEB1DlZG2m3TLfFtQ1hByB7fNgZNoRX67E4CdpDJezY7zoabasGDxFr2</aa>`),
-				ShouldEqual, "UTCwUZ6sibdSsefMTrPg52Ows4uQSBXKjM0gJAvKxf7CeXYvKzf5lJd1I2nP3hXQ3soi9GZLYZmpumeIYlRIq0PJiDO0c9WHW6dU8OaHAFx1C5eF3QA22Cr6sVsWRbr1cBXPqtvWgfnM0KNgDgGKtg7afSLSIdTMNI6xNx8AFB0COO6zp17V2HWeCVVgwmWct5UEB1DlZG2m3TLfFtQ1hByB7fNgZNoRX67E4CdpDJezY7zoabasGDxFr2")
-			So(HTML2Text(`<aa>UTCwUZ6sibdSsefMTrPg52Ows4uQSBXKjM0gJAvKxf7CeXYvKzf5lJd1I2nP3hXQ3soi9GZLYZmpumeIYlRIq0PJiDO0c9WHW6dU8OaHAFx1C5eF3QA22Cr6sVsWRbr1cBXPqtvWgfnM0KNgDgGKtg7afSLSIdTMNI6xNx8AFB0COO6zp17V2HWeCVVgwmWct5UEB1DlZG2m3TLfFtQ1hByB7fNgZNoRX67E4CdpDJezY7zoabasGDxFr2Rfino5IlkX1TyVRqx9dm2eTRdFAPW6xK4uPo8pVjmnqiQ4uOPtaJqkZhTwp60lX3fqrtzW1umqISS5Q6497tzBBghTwCoT2MC2GyRFJennWvvdjBsYQ9TQJbWfUxMLFKCG0PSis7Z3csFMJDwqd8kOImcrBvIShwm7nRa3zK16lZELCgNAtMVQPGpOTroS0o6w29tfX4C4S2KdzlCTiGu0QWO5Dmed4mIi8N2kml1dGNR6sHAoCqT5KWqE</aa>`),
-				ShouldEqual, "UTCwUZ6sibdSsefMTrPg52Ows4uQSBXKjM0gJAvKxf7CeXYvKzf5lJd1I2nP3hXQ3soi9GZLYZmpumeIYlRIq0PJiDO0c9WHW6dU8OaHAFx1C5eF3QA22Cr6sVsWRbr1cBXPqtvWgfnM0KNgDgGKtg7afSLSIdTMNI6xNx8AFB0COO6zp17V2HWeCVVgwmWct5UEB1DlZG2m3TLfFtQ1hByB7fNgZNoRX67E4CdpDJezY7zoabasGDxFr2\r\nRfino5IlkX1TyVRqx9dm2eTRdFAPW6xK4uPo8pVjmnqiQ4uOPtaJqkZhTwp60lX3fqrtzW1umqISS5Q6497tzBBghTwCoT2MC2GyRFJennWvvdjBsYQ9TQJbWfUxMLFKCG0PSis7Z3csFMJDwqd8kOImcrBvIShwm7nRa3zK16lZELCgNAtMVQPGpOTroS0o6w29tfX4C4S2KdzlCTiGu0QWO5Dmed4mIi8N2kml1dGNR6sHAoCqT5KWqE")
 		})
 
 	})


### PR DESCRIPTION
This PR includes code based on this library (https://github.com/k3a/html2text) but modified in order to prepend dashes ('-') for each list item, support ordered lists, and split lines longer than 250 characters into new lines.