### PR TITLE
Add more robust support for HTML5 anchor tags.

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -16,7 +16,7 @@ const (
 
 var legacyLBR = WIN_LBR
 var badTagnamesRE = regexp.MustCompile(`^(head|script|style|a)($|\s+)`)
-var linkTagRE = regexp.MustCompile(`a.*href=('([^']*?)'|"([^"]*?)")`)
+var linkTagRE = regexp.MustCompile(`^(?i:a)(?:$|\s).*(?i:href)\s*=\s*('([^']*?)'|"([^"]*?)"|([^\s"'` + "`" + `=<>]+))`)
 var badLinkHrefRE = regexp.MustCompile(`javascript:`)
 var headersRE = regexp.MustCompile(`^(\/)?h[1-6]`)
 var numericEntityRE = regexp.MustCompile(`(?i)^#(x?[a-f0-9]+)$`)
@@ -261,10 +261,13 @@ func HTML2TextWithOptions(html string, reqOpts ...Option) string {
 				// parse link href
 				// add special handling for a tags
 				m := linkTagRE.FindStringSubmatch(tag)
-				if len(m) == 4 {
+				if len(m) == 5 {
 					link := m[2]
 					if len(link) == 0 {
 						link = m[3]
+						if len(link) == 0 {
+							link = m[4]
+						}
 					}
 
 					if opts.linksInnerText && !badLinkHrefRE.MatchString(link) {
@@ -280,10 +283,13 @@ func HTML2TextWithOptions(html string, reqOpts ...Option) string {
 				if !opts.linksInnerText {
 					// parse link href
 					m := linkTagRE.FindStringSubmatch(tag)
-					if len(m) == 4 {
+					if len(m) == 5 {
 						link := m[2]
 						if len(link) == 0 {
 							link = m[3]
+							if len(link) == 0 {
+								link = m[4]
+							}
 						}
 
 						if !badLinkHrefRE.MatchString(link) {

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -15,6 +15,13 @@ func TestHTML2Text(t *testing.T) {
 
 			// the original behavior
 			So(HTML2Text(`click <a href="test">here</a>`), ShouldEqual, "click test")
+			So(HTML2Text(`click <A hRef="test">here</A>`), ShouldEqual, "click test")
+			So(HTML2Text(`click <a href='test'>here</a>`), ShouldEqual, "click test")
+			So(HTML2Text(`click <a href=test>here</a>`), ShouldEqual, "click test")
+			So(HTML2Text(`click <a href =test>here</a>`), ShouldEqual, "click test")
+			So(HTML2Text(`click <a href = test>here</a>`), ShouldEqual, "click test")
+			So(HTML2Text(`click <a href      =     test>here</a>`), ShouldEqual, "click test")
+			So(HTML2Text(`click <a href      =     test target="_blank">here</a>`), ShouldEqual, "click test")
 			So(HTML2Text(`click <a class="x" href="test">here</a>`), ShouldEqual, "click test")
 			So(HTML2Text(`click <a href="ents/&apos;x&apos;">here</a>`), ShouldEqual, "click ents/'x'")
 			So(HTML2Text(`click <a href="javascript:void(0)">here</a>`), ShouldEqual, "click ")
@@ -24,6 +31,13 @@ func TestHTML2Text(t *testing.T) {
 
 			// with inner text
 			So(HTML2TextWithOptions(`click <a href="test">here</a>`, WithLinksInnerText()), ShouldEqual, "click here <test>")
+			So(HTML2TextWithOptions(`click <A hRef="test">here</A>`, WithLinksInnerText()), ShouldEqual, "click here <test>")
+			So(HTML2TextWithOptions(`click <a href='test'>here</a>`, WithLinksInnerText()), ShouldEqual, "click here <test>")
+			So(HTML2TextWithOptions(`click <a href=test>here</a>`, WithLinksInnerText()), ShouldEqual, "click here <test>")
+			So(HTML2TextWithOptions(`click <a href =test>here</a>`, WithLinksInnerText()), ShouldEqual, "click here <test>")
+			So(HTML2TextWithOptions(`click <a href = test>here</a>`, WithLinksInnerText()), ShouldEqual, "click here <test>")
+			So(HTML2TextWithOptions(`click <a href      =     test>here</a>`, WithLinksInnerText()), ShouldEqual, "click here <test>")
+			So(HTML2TextWithOptions(`click <a href      =     test target="_blank">here</a>`, WithLinksInnerText()), ShouldEqual, "click here <test>")
 			So(HTML2TextWithOptions(`click <a class="x" href="test">here</a>`, WithLinksInnerText()), ShouldEqual, "click here <test>")
 			So(HTML2TextWithOptions(`click <a href="ents/&apos;x&apos;">here</a>`, WithLinksInnerText()), ShouldEqual, "click here <ents/'x'>")
 			So(HTML2TextWithOptions(`click <a href="javascript:void(0)">here</a>`, WithLinksInnerText()), ShouldEqual, "click here")
@@ -87,6 +101,7 @@ func TestHTML2Text(t *testing.T) {
 		Convey("Full HTML structure", func() {
 			So(HTML2Text(``), ShouldEqual, "")
 			So(HTML2Text(`<html><head><title>Good</title></head><body>x</body>`), ShouldEqual, "x")
+			So(HTML2Text(`<html><head href="foo"><title>Good</title></head><body>x</body>`), ShouldEqual, "x")
 			So(HTML2Text(`we are not <script type="javascript"></script>interested in scripts`),
 				ShouldEqual, "we are not interested in scripts")
 		})


### PR DESCRIPTION
This PR makes the anchor tag regex more robust so it can handle more of the HTML5 spec.

```
Old   a.*href=('([^']*?)'|"([^"]*?)")
New   ^(?i:a)(?:$|\s).*(?i:href)\s*=\s*('([^']*?)'|"([^"]*?)"|([^\s"'`=<>]+))
```

To break down the changes, in order:

| Regex | Reasoning |
| - | - |
| `^` | Check that the tag actually starts with the letter `a`, as opposed to say in the case of `head`. |
| `(?i:a)` | [Tags and attribute names are case insensitive](https://www.w3.org/TR/2011/WD-html5-20110405/syntax.html#syntax-tag-name), so we need a case-insensetive check. |
| `(?:$\|\s)` | We want only the letter `a` and not say `article`, so we check for the end the same way as `badTagnamesRE`. |
| `(?i:href)` | Case-insensetive check for attribute names as well. |
| `\s*=\s*` | [The equals sign can be surrounded by zero or more spaces.](https://www.w3.org/TR/2011/WD-html5-20110405/syntax.html#attributes-0) |
| ```\|([^\s"'`=<>]+)``` | [Attribute values don't have to be enclosed in quotes if they follow certain rules.](https://www.w3.org/TR/2011/WD-html5-20110405/syntax.html#unquoted) |
